### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,8 @@
 name: Docker
 
+permissions:
+  contents: read
+
 on:
   push:
     # Publish `main` as Docker `latest` image.


### PR DESCRIPTION
Potential fix for [https://github.com/eipm/beacon/security/code-scanning/1](https://github.com/eipm/beacon/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations (e.g., pushing Docker images to registries), the `contents: read` permission is sufficient for most steps, while additional permissions (if any) can be added as needed. For this workflow, no write permissions are explicitly required for GitHub resources, so we will start with `contents: read`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
